### PR TITLE
Improve expectations matcher

### DIFF
--- a/lib/mumukit/assistant/rule.rb
+++ b/lib/mumukit/assistant/rule.rb
@@ -22,11 +22,13 @@ module Mumukit::Assistant::Rule
   def self.parse_complex_when(w, message)
     condition, value = *w
     case condition.to_sym
-      when :error_contains                 then Mumukit::Assistant::Rule::ErrorContains.new(message, value)
-      when :these_tests_failed             then Mumukit::Assistant::Rule::TheseTestsFailed.new(message, value)
-      when :only_these_tests_failed        then Mumukit::Assistant::Rule::OnlyTheseTestsFailed.new(message, value)
-      when :these_expectations_failed      then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value)
-      when :only_these_expectations_failed then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value)
+      when :error_contains                             then Mumukit::Assistant::Rule::ErrorContains.new(message, value)
+      when :these_tests_failed                         then Mumukit::Assistant::Rule::TheseTestsFailed.new(message, value)
+      when :only_these_tests_failed                    then Mumukit::Assistant::Rule::OnlyTheseTestsFailed.new(message, value)
+      when :these_expectations_failed                  then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value)
+      when :only_these_expectations_failed             then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value)
+      when :submission_passed_with_these_warnings      then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value, strict: true)
+      when :submission_passed_with_these_only_warnings then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value, strict: true)
       else raise "Unsupported rule #{condition}"
     end
   end

--- a/lib/mumukit/assistant/rule.rb
+++ b/lib/mumukit/assistant/rule.rb
@@ -28,7 +28,7 @@ module Mumukit::Assistant::Rule
       when :these_expectations_failed                  then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value)
       when :only_these_expectations_failed             then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value)
       when :submission_passed_with_these_warnings      then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value, strict: true)
-      when :submission_passed_with_these_only_warnings then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value, strict: true)
+      when :submission_passed_with_only_these_warnings then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value, strict: true)
       else raise "Unsupported rule #{condition}"
     end
   end

--- a/lib/mumukit/assistant/rule.rb
+++ b/lib/mumukit/assistant/rule.rb
@@ -22,10 +22,11 @@ module Mumukit::Assistant::Rule
   def self.parse_complex_when(w, message)
     condition, value = *w
     case condition.to_sym
-      when :error_contains            then Mumukit::Assistant::Rule::ErrorContains.new(message, value)
-      when :these_tests_failed        then Mumukit::Assistant::Rule::TheseTestsFailed.new(message, value)
-      when :only_these_tests_failed   then Mumukit::Assistant::Rule::OnlyTheseTestsFailed.new(message, value)
-      when :these_expectations_failed then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value)
+      when :error_contains                 then Mumukit::Assistant::Rule::ErrorContains.new(message, value)
+      when :these_tests_failed             then Mumukit::Assistant::Rule::TheseTestsFailed.new(message, value)
+      when :only_these_tests_failed        then Mumukit::Assistant::Rule::OnlyTheseTestsFailed.new(message, value)
+      when :these_expectations_failed      then Mumukit::Assistant::Rule::TheseExpectationsFailed.new(message, value)
+      when :only_these_expectations_failed then Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed.new(message, value)
       else raise "Unsupported rule #{condition}"
     end
   end
@@ -38,5 +39,6 @@ require_relative 'rule/these_tests_failed.rb'
 require_relative 'rule/only_these_tests_failed.rb'
 require_relative 'rule/submission_passed_with_warnings.rb'
 require_relative 'rule/these_expectations_failed.rb'
+require_relative 'rule/only_these_expectations_failed.rb'
 require_relative 'rule/submission_errored.rb'
 require_relative 'rule/error_contains.rb'

--- a/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
@@ -2,8 +2,4 @@ class Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed < Mumukit::Assistant
   def matches_failing_expectations?(submission)
     super && failed_expectations(submission).count == @expectations.count
   end
-
-  def failed_expectations(submission)
-    submission.expectation_results.select { |it| it[:result].failed? }
-  end
 end

--- a/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
@@ -4,5 +4,6 @@ class Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed < Mumukit::Assistant
   end
 
   def failed_expectations(submission)
+    submission.expectation_results.select { |it| it[:result].failed? }
   end
 end

--- a/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/only_these_expectations_failed.rb
@@ -1,0 +1,8 @@
+class Mumukit::Assistant::Rule::OnlyTheseExpectationsFailed < Mumukit::Assistant::Rule::TheseExpectationsFailed
+  def matches_failing_expectations?(submission)
+    super && failed_expectations(submission).count == @expectations.count
+  end
+
+  def failed_expectations(submission)
+  end
+end

--- a/lib/mumukit/assistant/rule/these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/these_expectations_failed.rb
@@ -11,12 +11,16 @@ class Mumukit::Assistant::Rule::TheseExpectationsFailed < Mumukit::Assistant::Ru
 
   def matches_failing_expectations?(submission)
     @expectations.all? do |it|
-      includes_failing_expectation? it, submission.expectation_results
+      includes_failing_expectation? it, submission
     end
   end
 
-  def includes_failing_expectation?(humanized_expectation, expectation_results)
+  def failed_expectations(submission)
+    @failed_expectations ||= submission.expectation_results.select { |it| it[:result].failed? }
+  end
+
+  def includes_failing_expectation?(humanized_expectation, submission)
     binding, inspection = humanized_expectation.split(' ')
-    expectation_results.include? binding: binding, inspection: inspection, result: :failed
+    failed_expectations(submission).any? { |it| it[:binding] == binding && it[:inspection] == inspection }
   end
 end

--- a/lib/mumukit/assistant/rule/these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/these_expectations_failed.rb
@@ -1,12 +1,13 @@
 class Mumukit::Assistant::Rule::TheseExpectationsFailed < Mumukit::Assistant::Rule::SubmissionPassedWithWarnings
-  def initialize(message, expectations)
+  def initialize(message, expectations, strict: false)
     raise 'missing expectations' if expectations.blank?
     super(message)
     @expectations = expectations
+    @strict = strict
   end
 
   def matches?(submission)
-    super && matches_failing_expectations?(submission)
+    (!@strict || super) && matches_failing_expectations?(submission)
   end
 
   def matches_failing_expectations?(submission)

--- a/lib/mumukit/assistant/rule/these_tests_failed.rb
+++ b/lib/mumukit/assistant/rule/these_tests_failed.rb
@@ -20,6 +20,6 @@ class Mumukit::Assistant::Rule::TheseTestsFailed < Mumukit::Assistant::Rule::Sub
   end
 
   def failed_tests(submission)
-    submission.test_results.select { |it| it[:status].failed? }
+    @failed_tests ||= submission.test_results.select { |it| it[:status].failed? }
   end
 end

--- a/mumukit-assistant.gemspec
+++ b/mumukit-assistant.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '>= 1.16', '< 3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3'
 

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -280,7 +280,7 @@ describe Mumukit::Assistant do
                 {binding: "Foo", inspection: "DeclaresAttribute:bar", result: :failed},
                 {binding: "foo", inspection: "DeclaresAttribute:baz", result: :passed}] }
 
-      it { expect(assistant.assist_with submission).to eq ['sdsad'] }
+      it { expect(assistant.assist_with submission).to eq ['You must declare getter bar'] }
     end
   end
 

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -205,6 +205,40 @@ describe Mumukit::Assistant do
     end
   end
 
+  describe 'submission_passed_with_warnings with strict expectations' do
+    let(:rules) {[{
+      when: {
+        submission_passed_with_these_warnings: [
+          'Foo DeclaresMethod:getBar',
+          'Foo DeclaresAttribute:bar'
+        ]
+      },
+      then: 'You must declare getter bar'
+    }]}
+
+    context 'when submission has failed with matching expectations' do
+      let(:submission) {
+        struct status: :failed,
+               expectation_results: [
+                 {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                 {binding: "Foo", inspection: "DeclaresAttribute:bar",  result: :failed},
+                 {binding: "foo", inspection: "DeclaresAttribute:baz", result: :failed}] }
+
+      it { expect(assistant.assist_with submission).to eq [] }
+    end
+
+    context 'when submission has passed_with_warnings with matching expectations' do
+      let(:submission) {
+        struct status: :passed_with_warnings,
+               expectation_results: [
+                 {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                 {binding: "Foo", inspection: "DeclaresAttribute:bar",  result: :failed},
+                 {binding: "foo", inspection: "DeclaresAttribute:baz", result: :failed}] }
+
+      it { expect(assistant.assist_with submission).to eq ['You must declare getter bar'] }
+    end
+  end
+
   describe 'submission_passed_with_warnings with expectations' do
     let(:rules) {[{
       when: {
@@ -219,6 +253,17 @@ describe Mumukit::Assistant do
     context 'when submission has passed_with_warnings with matching expectations' do
       let(:submission) {
         struct status: :passed_with_warnings,
+               expectation_results: [
+                 {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                 {binding: "Foo", inspection: "DeclaresAttribute:bar",  result: :failed},
+                 {binding: "foo", inspection: "DeclaresAttribute:baz", result: :failed}] }
+
+      it { expect(assistant.assist_with submission).to eq ['You must declare getter bar'] }
+    end
+
+    context 'when submission has failed with matching expectations' do
+      let(:submission) {
+        struct status: :failed,
                expectation_results: [
                  {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
                  {binding: "Foo", inspection: "DeclaresAttribute:bar",  result: :failed},
@@ -282,7 +327,19 @@ describe Mumukit::Assistant do
 
       it { expect(assistant.assist_with submission).to eq ['You must declare getter bar'] }
     end
+
+    context 'when submission has failed with matching expectations only' do
+      let(:submission) {
+        struct status: :failed,
+               expectation_results: [
+                {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                {binding: "Foo", inspection: "DeclaresAttribute:bar", result: :failed},
+                {binding: "foo", inspection: "DeclaresAttribute:baz", result: :passed}] }
+
+      it { expect(assistant.assist_with submission).to eq ['You must declare getter bar'] }
+    end
   end
+
 
 end
 

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -239,5 +239,50 @@ describe Mumukit::Assistant do
     end
   end
 
+  describe 'submission_passed_with_warnings with expectations only' do
+    let(:rules) {[{
+      when: {
+        only_these_expectations_failed: [
+          'Foo DeclaresMethod:getBar',
+          'Foo DeclaresAttribute:bar'
+        ]
+      },
+      then: 'You must declare getter bar'
+    }]}
+
+    context 'when submission has passed_with_warnings with matching expectations, plus some others' do
+      let(:submission) {
+        struct status: :passed_with_warnings,
+               expectation_results: [
+                 {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                 {binding: "Foo", inspection: "DeclaresAttribute:bar", result: :failed},
+                 {binding: "foo", inspection: "DeclaresAttribute:baz", result: :failed}] }
+
+      it { expect(assistant.assist_with submission).to eq [] }
+    end
+
+    context 'when submission has passed_with_warnings without matching all expectations' do
+      let(:submission) {
+        struct status: :passed_with_warnings,
+               expectation_results: [
+                {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                {binding: "Foo", inspection: "DeclaresAttribute:bar", result: :passed},
+                {binding: "foo", inspection: "DeclaresAttribute:baz", result: :failed}] }
+
+      it { expect(assistant.assist_with submission).to eq [] }
+    end
+
+    context 'when submission has passed_with_warnings with matching expectations only' do
+      let(:submission) {
+        struct status: :passed_with_warnings,
+               expectation_results: [
+                {binding: "Foo", inspection: "DeclaresMethod:getBar", result: :failed},
+                {binding: "Foo", inspection: "DeclaresAttribute:bar", result: :failed},
+                {binding: "foo", inspection: "DeclaresAttribute:baz", result: :passed}] }
+
+      it { expect(assistant.assist_with submission).to eq ['sdsad'] }
+    end
+  end
+
 end
 


### PR DESCRIPTION
Fixes https://github.com/mumuki/mumuki-laboratory/issues/1359

This PR introduces new rules: 

* `submission_passed_with_these_warnings`: stricter version of `these_expectations_failed`, that checks the submission status
* `submission_passed_with_only_these_warnings` stricter version of `only_these_expectations_failed`, that checks the submission status
* `only_these_expectations_failed`: analogue to `only_these_tests_failed`
 
Also, it relaxes `these_expectations_failed` to work also with non-`passed-with-warnings` submissions