### PR TITLE
Trimming test titles

### DIFF
--- a/lib/mumukit/assistant/rule/these_tests_failed.rb
+++ b/lib/mumukit/assistant/rule/these_tests_failed.rb
@@ -16,7 +16,7 @@ class Mumukit::Assistant::Rule::TheseTestsFailed < Mumukit::Assistant::Rule::Sub
   end
 
   def includes_failing_test?(title, submission)
-    failed_tests(submission).map { |it| it[:title] }.include?(title)
+    failed_tests(submission).map { |it| it[:title].strip }.include?(title.strip)
   end
 
   def failed_tests(submission)

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -128,6 +128,40 @@ describe Mumukit::Assistant do
       it { expect(assistant.assist_with submission).to eq ['oops, failed!'] }
     end
 
+    context 'when given tests have failed, with trimming' do
+      let(:submission) {
+        struct status: :failed,
+               test_results: [
+                  {title: ' f -2 should return 1', status: :failed, result: '.'},
+                  {title: '  f -5 should return 1  ', status: :failed, result: '.'},
+                  {title: 'f -6 should return 1', status: :failed, result: '.'},
+               ]
+      }
+      it { expect(assistant.assist_with submission).to eq ['oops, failed!'] }
+    end
+
+    context 'when given tests have failed, with trimming in both rules and tests' do
+      let(:rules) {[
+        {
+          when: {
+            these_tests_failed: [
+              'f -2 should return 1  ',
+              ' f -5 should return 1']
+          },
+          then: 'oops, failed!'}
+      ]}
+
+      let(:submission) {
+        struct status: :failed,
+               test_results: [
+                  {title: ' f -2 should return 1', status: :failed, result: '.'},
+                  {title: '  f -5 should return 1  ', status: :failed, result: '.'},
+                  {title: 'f -6 should return 1', status: :failed, result: '.'},
+               ]
+      }
+      it { expect(assistant.assist_with submission).to eq ['oops, failed!'] }
+    end
+
     context 'when given tests have not failed' do
       let(:submission) {
         struct status: :failed,


### PR DESCRIPTION
Although not technically a bug, making test titles sensitive to leading and trailing spaces is very error prone, so I am trimming them