### PR TITLE
Chore more robust parsing

### DIFF
--- a/lib/mumukit/assistant/rule.rb
+++ b/lib/mumukit/assistant/rule.rb
@@ -1,7 +1,7 @@
 module Mumukit::Assistant::Rule
   def self.parse(hash)
-    message = Mumukit::Assistant::Message.parse hash[:then]
-    w = hash[:when]
+    message = Mumukit::Assistant::Message.parse hash.indifferent_get(:then)
+    w = hash.indifferent_get(:when)
     if w.is_a? Hash
       parse_complex_when w.first, message
     else

--- a/lib/mumukit/assistant/rule/content_empty.rb
+++ b/lib/mumukit/assistant/rule/content_empty.rb
@@ -1,5 +1,5 @@
 class Mumukit::Assistant::Rule::ContentEmpty < Mumukit::Assistant::Rule::Base
   def matches?(submission)
-    submission.solution.empty?
+    submission.solution.blank?
   end
 end

--- a/lib/mumukit/assistant/rule/these_expectations_failed.rb
+++ b/lib/mumukit/assistant/rule/these_expectations_failed.rb
@@ -17,11 +17,11 @@ class Mumukit::Assistant::Rule::TheseExpectationsFailed < Mumukit::Assistant::Ru
   end
 
   def failed_expectations(submission)
-    @failed_expectations ||= submission.expectation_results.select { |it| it[:result].failed? }
+    @failed_expectations ||= submission.expectation_results.select { |it| it.indifferent_get(:result).failed? }
   end
 
   def includes_failing_expectation?(humanized_expectation, submission)
     binding, inspection = humanized_expectation.split(' ')
-    failed_expectations(submission).any? { |it| it[:binding] == binding && it[:inspection] == inspection }
+    failed_expectations(submission).any? { |it| it.indifferent_get(:binding) == binding && it.indifferent_get(:inspection) == inspection }
   end
 end

--- a/lib/mumukit/assistant/rule/these_tests_failed.rb
+++ b/lib/mumukit/assistant/rule/these_tests_failed.rb
@@ -16,10 +16,10 @@ class Mumukit::Assistant::Rule::TheseTestsFailed < Mumukit::Assistant::Rule::Sub
   end
 
   def includes_failing_test?(title, submission)
-    failed_tests(submission).map { |it| it[:title].strip }.include?(title.strip)
+    failed_tests(submission).map { |it| it.indifferent_get(:title).strip }.include?(title.strip)
   end
 
   def failed_tests(submission)
-    @failed_tests ||= submission.test_results.select { |it| it[:status].failed? }
+    @failed_tests ||= submission.test_results.select { |it| it.indifferent_get(:status).failed? }
   end
 end

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -22,6 +22,13 @@ describe Mumukit::Assistant do
       let(:submission) { struct solution: '' }
       it { expect(assistant.assist_with submission).to eq ['oops, please write something in the editor'] }
     end
+
+    context 'string keys' do
+      let(:rules) {[ {'when' => 'content_empty', 'then' => 'oops, please write something in the editor'} ]}
+      let(:submission) { struct solution: '' }
+
+      it { expect(assistant.assist_with submission).to eq ['oops, please write something in the editor'] }
+    end
   end
 
   describe 'content_empty with attemps_count' do
@@ -120,6 +127,30 @@ describe Mumukit::Assistant do
         },
         then: 'oops, failed!'}
     ]}
+
+
+    context 'sttring keys' do
+      let(:rules) {[
+        {
+          'when' => {
+            'these_tests_failed' => [
+              'f -2 should return 1',
+              'f -5 should return 1']
+          },
+          'then' => 'oops, failed!'}
+      ]}
+
+      let(:submission) {
+        struct status: :failed,
+               test_results: [
+                  {title: 'f -2 should return 1', status: :failed, result: '.'},
+                  {title: 'f -5 should return 1', status: :failed, result: '.'},
+                  {title: 'f -6 should return 1', status: :failed, result: '.'},
+               ]
+      }
+      it { expect(assistant.assist_with submission).to eq ['oops, failed!'] }
+    end
+
 
     context 'when given tests have failed' do
       let(:submission) {

--- a/spec/mumukit/assistant_spec.rb
+++ b/spec/mumukit/assistant_spec.rb
@@ -8,6 +8,11 @@ describe Mumukit::Assistant do
       {when: :content_empty, then: 'oops, please write something in the editor'}
     ]}
 
+    context 'when submission has nil content' do
+      let(:submission) { struct solution: nil }
+      it { expect(assistant.assist_with submission).to eq ['oops, please write something in the editor'] }
+    end
+
     context 'when submission has content' do
       let(:submission) { struct solution: 'something' }
       it { expect(assistant.assist_with submission).to eq [] }


### PR DESCRIPTION
Making assistant support string keys and allowing nil solutions.

This PR does not fix any bug. I am just introducing this changes to make assistant more resilient in tests contexts. 